### PR TITLE
fix(api): pass user agent when proxying news api

### DIFF
--- a/public/api/NewsApi.php
+++ b/public/api/NewsApi.php
@@ -19,6 +19,7 @@ class NewsApi {
     curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "GET");
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($curl, CURLOPT_REFERER, 'https://localhost:3000');
+    curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']);
 
     $server_output = curl_exec ($curl);
 


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Fix missing user-agent error when proxying news-api

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
1. Verified that the API does not return any error by starting React app

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [x] Bug fix - `fix`
- [ ] Refactor - `refactor`
- [ ] Test - `test`
- [ ] Other(s): <!-- Fill the type of changes here -->

## Checklist:
- [ ] Test have been written for utilities.
- [ ] I have test my code on different platforms and devices.

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
